### PR TITLE
fix(welcome): clip background image to prevent covering LoadingView

### DIFF
--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/WelcomeView.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/WelcomeView.swift
@@ -11,32 +11,66 @@ import PapyrusStyleKit
 
 struct WelcomeView: View {
     @EnvironmentObject var store: ReaderStore
-    @Binding var isSequelMode: Bool
-    
+    @Environment(\.papyrusColorScheme) private var colorScheme
+    @Environment(\.papyrusBackgroundImage) private var backgroundImage
+
+    private var isShowingBackgroundImage: Bool {
+        backgroundImage.usage.contains(.home) && backgroundImage.image != nil
+    }
+
     var body: some View {
         ZStack {
             // Bottom content (New Story button)
             VStack {
                 Spacer()
-                SDIcons.scroll.image
-                    .frame(width: 64, height: 64)
-                    .foregroundColor(PapyrusColor.iconPrimary.color)
-                    .opacity(0.5)
+
+                if !isShowingBackgroundImage {
+                    SDIcons.scroll.image
+                        .frame(width: 64, height: 64)
+                        .saturation(colorScheme == .parchment ? 1 : 0)
+                        .colorMultiply(colorScheme == .parchment ? .white : PapyrusColor.iconPrimary.color(in: colorScheme))
+                        .opacity(0.5)
+                }
+
                 Spacer()
-                
+
                 // Initial "New Story" button
-                PrimaryButton(
-                    type: .newStory,
-                    isDisabled: false,
-                    isLoading: store.state.isLoading
-                ) {
+                PrimaryButton(isLoading: store.state.isLoading, fontName: store.state.settingsState.selectedFontName) {
                     withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
                         store.dispatch(.setShowStoryForm(true))
                     }
                 }
-                    .padding(.bottom, 30)
+                .padding(.bottom, 30)
             }
             .padding(.horizontal, 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            if let img = backgroundImage.image, backgroundImage.usage.contains(.home) {
+                ZStack(alignment: .bottom) {
+                    img
+                        .resizable()
+                        .scaledToFill()
+                        .clipped()
+
+                    LinearGradient(
+                        colors: [.clear, .black.opacity(0.55)],
+                        startPoint: .center,
+                        endPoint: .bottom
+                    )
+                }
+                .clipped()
+            } else {
+                LinearGradient(
+                    gradient: Gradient(colors: [
+                        PapyrusColor.background.color(in: colorScheme),
+                        PapyrusColor.backgroundSecondary.color(in: colorScheme)
+                    ]),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5.

- Adds `.clipped()` to the outer `ZStack(alignment: .bottom)` inside `WelcomeView`'s `.background` block
- Prevents the background image from visually overflowing its bounds and covering `LoadingView`
- Also brings `WelcomeView.swift` up to date with the latest version on `develop` (background image support, color scheme environment, updated `PrimaryButton` signature)

## Test plan

- [ ] Open the app and verify that `LoadingView` is visible and not obscured when a background image is set for the home screen
- [ ] Verify the background image still displays correctly within `WelcomeView` bounds
- [ ] Verify the gradient overlay still appears at the bottom of the background image
- [ ] Verify the fallback `LinearGradient` background still works when no background image is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)