### PR TITLE
refactor(reader): remove binding params from UnifiedNavigationBar, use store directly

### DIFF
--- a/papyrus/papyrus/Packages/Reader/Mocks/ReaderState+Arrange.swift
+++ b/papyrus/papyrus/Packages/Reader/Mocks/ReaderState+Arrange.swift
@@ -25,7 +25,8 @@ public extension ReaderState {
         settingsState: SettingsState = SettingsState(),
         showStoryForm: Bool = false,
         showSubscriptionSheet: Bool = false,
-        selectedStoryForDetails: Story? = nil
+        selectedStoryForDetails: Story? = nil,
+        menuStatus: MenuStatus = .closed
     ) -> ReaderState {
         .init(
             mainCharacter: mainCharacter,
@@ -38,7 +39,8 @@ public extension ReaderState {
             settingsState: settingsState,
             showStoryForm: showStoryForm,
             showSubscriptionSheet: showSubscriptionSheet,
-            selectedStoryForDetails: selectedStoryForDetails
+            selectedStoryForDetails: selectedStoryForDetails,
+            menuStatus: menuStatus
         )
     }
 }

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderAction.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderAction.swift
@@ -46,4 +46,5 @@ enum ReaderAction: Equatable, Sendable {
     case setShowSubscriptionSheet(Bool)
     case loadSubscriptions
     case setSelectedStoryForDetails(Story?)
+    case setMenuStatus(MenuStatus)
 }

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
@@ -143,6 +143,8 @@ let readerReducer: Reducer<ReaderState, ReaderAction> = { state, action in
         newState.showSubscriptionSheet = show
     case .setSelectedStoryForDetails(let story):
         newState.selectedStoryForDetails = story
+    case .setMenuStatus(let status):
+        newState.menuStatus = status
     case .saveStory,
             .deleteStory,
             .loadSubscriptions,

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderState.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderState.swift
@@ -8,6 +8,12 @@
 import TextGeneration
 import Settings
 
+public enum MenuStatus: Equatable, Sendable {
+    case closed
+    case storyOpen
+    case settingsOpen
+}
+
 public struct ReaderState: Equatable {
     var mainCharacter: String
     var setting: String
@@ -20,6 +26,7 @@ public struct ReaderState: Equatable {
     var showStoryForm: Bool
     var showSubscriptionSheet: Bool
     var selectedStoryForDetails: Story?
+    var menuStatus: MenuStatus
 
     public init(
         mainCharacter: String = "",
@@ -32,7 +39,8 @@ public struct ReaderState: Equatable {
         settingsState: SettingsState = SettingsState(),
         showStoryForm: Bool = false,
         showSubscriptionSheet: Bool = false,
-        selectedStoryForDetails: Story? = nil
+        selectedStoryForDetails: Story? = nil,
+        menuStatus: MenuStatus = .closed
     ) {
         self.mainCharacter = mainCharacter
         self.setting = setting
@@ -45,6 +53,7 @@ public struct ReaderState: Equatable {
         self.showStoryForm = showStoryForm
         self.showSubscriptionSheet = showSubscriptionSheet
         self.selectedStoryForDetails = selectedStoryForDetails
+        self.menuStatus = menuStatus
     }
     
     // Computed property to check if user can create more chapters

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/MenuGestureHandler.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/MenuGestureHandler.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MenuGestureHandler: ViewModifier {
-    @Binding var menuStatus: ReaderView.MenuStatus
+    @Binding var menuStatus: MenuStatus
     @Binding var dragOffset: CGFloat
     
     // Configuration
@@ -17,7 +17,7 @@ struct MenuGestureHandler: ViewModifier {
     let isForClosing: Bool
     
     init(
-        menuStatus: Binding<ReaderView.MenuStatus>,
+        menuStatus: Binding<MenuStatus>,
         dragOffset: Binding<CGFloat>,
         openThreshold: CGFloat,
         closeThreshold: CGFloat,
@@ -85,7 +85,7 @@ struct MenuGestureHandler: ViewModifier {
 
 extension View {
     func menuGestures(
-        menuStatus: Binding<ReaderView.MenuStatus>,
+        menuStatus: Binding<MenuStatus>,
         dragOffset: Binding<CGFloat>,
         openThreshold: CGFloat = 50,
         closeThreshold: CGFloat = 50,

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/ReaderView.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/ReaderView.swift
@@ -12,36 +12,29 @@ import PapyrusStyleKit
 
 struct ReaderView: View {
     @EnvironmentObject var store: ReaderStore
-    @State private var menuStatus: MenuStatus = .closed
     @State private var dragOffset: CGFloat = 0
     @FocusState private var focusedField: Field?
     @State private var isSequelMode: Bool = false
     @State private var currentScrollOffset: CGFloat = 0
     @State private var scrollOffsetTimer: Timer?
     @State private var scrollViewHeight: CGFloat = 0
-    
-    enum MenuStatus {
-        case closed
-        case storyOpen
-        case settingsOpen
-    }
-    
+
     enum Field {
         case mainCharacter
         case settingDetails
     }
-    
+
     init() {
-        
+
     }
-    
+
     public var body: some View {
         let showStoryForm: Binding<Bool> = .init {
             store.state.showStoryForm
         } set: { newValue in
             store.dispatch(.setShowStoryForm(newValue))
         }
-        
+
         let showSubscriptionSheet: Binding<Bool> = .init {
             store.state.showSubscriptionSheet
         } set: { newValue in
@@ -50,13 +43,13 @@ struct ReaderView: View {
         ZStack(alignment: .leading) {
             // Main content
             VStack(spacing: 0) {
-                
+
                 // Loading bar (appears below top bar when loading)
                 if store.state.isLoading {
                     LoadingView(loadingStep: store.state.loadingStep, hasExistingStory: store.state.story != nil)
                         .transition(.move(edge: .top).combined(with: .opacity))
                 }
-                
+
                 ContentStateView(
                     focusedField: $focusedField,
                     isSequelMode: $isSequelMode,
@@ -78,69 +71,50 @@ struct ReaderView: View {
                 .scrollBounceBehavior(.basedOnSize)
                 .animation(.easeInOut(duration: 0.4), value: store.state.isLoading)
                 .menuGestures(
-                    menuStatus: $menuStatus,
+                    menuStatus: Binding(
+                        get: { store.state.menuStatus },
+                        set: { store.dispatch(.setMenuStatus($0)) }
+                    ),
                     dragOffset: $dragOffset
                 )
-                
-                UnifiedNavigationBar(
-                    isMenuOpen: Binding(
-                        get: { menuStatus == .storyOpen },
-                        set: { newValue in
-                            if newValue {
-                                menuStatus = .storyOpen
-                            } else {
-                                menuStatus = .closed
-                            }
-                        }
-                    ),
-                    isSettingsOpen: Binding(
-                        get: { menuStatus == .settingsOpen },
-                        set: { newValue in
-                            if newValue {
-                                menuStatus = .settingsOpen
-                            } else {
-                                menuStatus = .closed
-                            }
-                        }
-                    )
-                )
+
+                UnifiedNavigationBar()
             }
-            
+
             // Modal overlay for both menu and settings
             ModalOverlay(
-                isPresented: menuStatus != .closed,
+                isPresented: store.state.menuStatus != .closed,
                 opacity: calculateOverlayOpacity(),
                 onDismiss: {
-                    menuStatus = .closed
+                    store.dispatch(.setMenuStatus(.closed))
                 }
             )
             .menuGestures(
-                menuStatus: $menuStatus,
+                menuStatus: Binding(
+                    get: { store.state.menuStatus },
+                    set: { store.dispatch(.setMenuStatus($0)) }
+                ),
                 dragOffset: $dragOffset,
                 isForClosing: true
             )
-            
+
             // Side menu
             StoryMenu(
                 isMenuOpen: Binding(
-                    get: { menuStatus == .storyOpen },
+                    get: { store.state.menuStatus == .storyOpen },
                     set: { newValue in
-                        if newValue {
-                            menuStatus = .storyOpen
-                        } else {
-                            menuStatus = .closed
-                        }
+                        store.dispatch(.setMenuStatus(newValue ? .storyOpen : .closed))
                     }
                 ),
                 dragOffset: dragOffset,
-                menuStatus: menuStatus
+                menuStatus: store.state.menuStatus
             )
-            
+
             // Settings menu (slides from right)
             SettingsMenu(
-                isOpen: menuStatus == .settingsOpen,
+                isOpen: store.state.menuStatus == .settingsOpen,
                 dragOffset: dragOffset,
-                menuStatus: menuStatus
+                menuStatus: store.state.menuStatus
             )
         }
         .sheet(isPresented: showStoryForm) {
@@ -160,7 +134,7 @@ struct ReaderView: View {
             store.dispatch(.loadSubscriptions)
         }
     }
-    
+
     private func startScrollOffsetTimer() {
         scrollOffsetTimer?.invalidate()
         scrollOffsetTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
@@ -172,11 +146,11 @@ struct ReaderView: View {
             }
         }
     }
-    
+
     private func calculateOverlayOpacity() -> Double {
         var opacity: Double = 0
-        
-        switch menuStatus {
+
+        switch store.state.menuStatus {
         case .storyOpen:
             // When menu is open
             if dragOffset < 0 {
@@ -185,7 +159,7 @@ struct ReaderView: View {
             } else {
                 opacity = 0.3
             }
-            
+
         case .settingsOpen:
             // When settings is open
             if dragOffset > 0 {
@@ -194,7 +168,7 @@ struct ReaderView: View {
             } else {
                 opacity = 0.3
             }
-            
+
         case .closed:
             // When both are closed, calculate based on drag direction
             if dragOffset > 0 {
@@ -205,7 +179,7 @@ struct ReaderView: View {
                 opacity = Double(abs(dragOffset) / 280.0) * 0.3
             }
         }
-        
+
         return max(0, min(opacity, 0.3))
     }
 }

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Menu/SettingsMenu.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Menu/SettingsMenu.swift
@@ -14,7 +14,7 @@ struct SettingsMenu: View {
     @EnvironmentObject var store: ReaderStore
     let isOpen: Bool
     let dragOffset: CGFloat
-    let menuStatus: ReaderView.MenuStatus
+    let menuStatus: MenuStatus
     
     var body: some View {
         HStack {

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Menu/StoryMenu.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Menu/StoryMenu.swift
@@ -13,7 +13,7 @@ struct StoryMenu: View {
     @EnvironmentObject var store: ReaderStore
     @Binding var isMenuOpen: Bool
     let dragOffset: CGFloat
-    let menuStatus: ReaderView.MenuStatus
+    let menuStatus: MenuStatus
     @State private var isSequelMode = false
     @FocusState private var focusedField: ReaderView.Field?
     

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Navigation Bar/UnifiedNavigationBar.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Navigation Bar/UnifiedNavigationBar.swift
@@ -11,36 +11,36 @@ import PapyrusStyleKit
 
 struct UnifiedNavigationBar: View {
     @EnvironmentObject var store: ReaderStore
-    @Binding var isMenuOpen: Bool
-    @Binding var isSettingsOpen: Bool
-    
+
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 // Menu button (left)
                 MenuButton(type: .menu) {
                     withAnimation(.easeInOut(duration: 0.3)) {
-                        isMenuOpen.toggle()
+                        let newStatus: MenuStatus = store.state.menuStatus == .storyOpen ? .closed : .storyOpen
+                        store.dispatch(.setMenuStatus(newStatus))
                     }
                 }
-                
+
                 // Chapter navigation (center) - only show when story exists
                 if let story = store.state.story,
                    !story.chapters.isEmpty,
                    story.chapterIndex < story.chapters.count {
                     Spacer()
-                    
+
                     ChapterNavigationView(story: story)
-                    
+
                     Spacer()
                 } else {
                     Spacer()
                 }
-                
+
                 // Settings button (right)
                 MenuButton(type: .settings) {
                     withAnimation(.easeInOut(duration: 0.3)) {
-                        isSettingsOpen.toggle()
+                        let newStatus: MenuStatus = store.state.menuStatus == .settingsOpen ? .closed : .settingsOpen
+                        store.dispatch(.setMenuStatus(newStatus))
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Moves `MenuStatus` enum from `ReaderView` to `ReaderState` as a top-level public enum
- Adds `setMenuStatus` action to `ReaderAction` and handles it in `ReaderReducer`
- Removes `@Binding var isMenuOpen` and `@Binding var isSettingsOpen` from `UnifiedNavigationBar`, replacing them with direct reads from `store.state.menuStatus` and dispatches via `store.dispatch(.setMenuStatus(...))`
- Simplifies the call site in `ReaderView` from a verbose inline `Binding` construction to just `UnifiedNavigationBar()`
- Updates `MenuGestureHandler`, `StoryMenu`, and `SettingsMenu` to use the module-level `MenuStatus` type instead of the former `ReaderView.MenuStatus` nested type

Closes #4

## Test plan

- [ ] Build succeeds with no compiler errors
- [ ] Tapping the menu button opens the story menu and tapping again closes it
- [ ] Tapping the settings button opens the settings menu and tapping again closes it
- [ ] Drag gestures to open/close menus still work correctly
- [ ] Modal overlay dismisses menus when tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)