### PR TITLE
refactor(reader): remove binding params from UnifiedNavigationBar, use store directly

### DIFF
--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/ReaderView.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Main Content/ReaderView.swift
@@ -81,24 +81,7 @@ struct ReaderView: View {
                     isEnabled: !store.state.contentState.hasStory
                 )
 
-                UnifiedNavigationBar(
-                    isMenuOpen: Binding(
-                        get: { store.state.menuStatus == .storyOpen },
-                        set: { newValue in
-                            withAnimation(.easeInOut(duration: 0.3)) {
-                                store.dispatch(.setMenuStatus(newValue ? .storyOpen : .closed))
-                            }
-                        }
-                    ),
-                    isSettingsOpen: Binding(
-                        get: { store.state.menuStatus == .settingsOpen },
-                        set: { newValue in
-                            withAnimation(.easeInOut(duration: 0.3)) {
-                                store.dispatch(.setMenuStatus(newValue ? .settingsOpen : .closed))
-                            }
-                        }
-                    )
-                )
+                UnifiedNavigationBar()
                 .ignoresSafeArea(.keyboard)
             }
             .environment(\.readerFocusedField, $focusedField)

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Navigation Bar/UnifiedNavigationBar.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/View/Navigation Bar/UnifiedNavigationBar.swift
@@ -12,8 +12,6 @@ import PapyrusStyleKit
 struct UnifiedNavigationBar: View {
     @EnvironmentObject var store: ReaderStore
     @Environment(\.papyrusColorScheme) private var colorScheme
-    @Binding var isMenuOpen: Bool
-    @Binding var isSettingsOpen: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -21,7 +19,8 @@ struct UnifiedNavigationBar: View {
                 // Menu button (left)
                 MenuButton(type: .menu) {
                     withAnimation(.easeInOut(duration: 0.3)) {
-                        isMenuOpen.toggle()
+                        let newStatus: MenuStatus = store.state.menuStatus == .storyOpen ? .closed : .storyOpen
+                        store.dispatch(.setMenuStatus(newStatus))
                     }
                 }
 
@@ -42,7 +41,8 @@ struct UnifiedNavigationBar: View {
                 // Settings button (right)
                 MenuButton(type: .settings) {
                     withAnimation(.easeInOut(duration: 0.3)) {
-                        isSettingsOpen.toggle()
+                        let newStatus: MenuStatus = store.state.menuStatus == .settingsOpen ? .closed : .settingsOpen
+                        store.dispatch(.setMenuStatus(newStatus))
                     }
                 }
             }


### PR DESCRIPTION
Closes #4

## Summary
- Removed `@Binding var isMenuOpen` and `@Binding var isSettingsOpen` from `UnifiedNavigationBar`
- Buttons now read `store.state.menuStatus` and dispatch `.setMenuStatus(...)` directly
- Simplified call site in `ReaderView` from verbose inline-Binding construction to `UnifiedNavigationBar()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)