### PR TITLE
fix(reader): remove canCreateChapter gate from createStory actions

### DIFF
--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
@@ -15,17 +15,9 @@ let readerMiddleware: Middleware<ReaderState, ReaderAction, ReaderEnvironmentPro
     // MARK: - Entry Points (subscription gate lives here)
 
     case .createStory:
-        if !state.canCreateChapter {
-            let isSubscribed = await (try? environment.subscriptionEnvironment.checkSubscriptionStatus()) ?? false
-            if !isSubscribed { return .setShowSubscriptionSheet(true) }
-        }
         return .beginCreateStory
 
     case .createInteractiveStory:
-        if !state.canCreateChapter {
-            let isSubscribed = await (try? environment.subscriptionEnvironment.checkSubscriptionStatus()) ?? false
-            if !isSubscribed { return .setShowSubscriptionSheet(true) }
-        }
         return .beginCreateInteractiveStory
 
     case .createSequel:


### PR DESCRIPTION
## Summary
- `.createStory` and `.createInteractiveStory` middleware cases were incorrectly guarded by `canCreateChapter`, which checks the chapter count of the *currently open* story
- When a story with 2+ chapters was open, tapping "New Story" triggered the subscription sheet instead of opening the new story form
- Removed the subscription gate from both cases since new stories always start with zero chapters — there is nothing to gate

## Test plan
- [ ] Open a story that has 2 or more chapters
- [ ] Open StoryMenu and tap "New Story" — verify the NewStoryForm opens (not the subscription sheet)
- [ ] Repeat for "New Interactive Story" if available in the menu
- [ ] Confirm that adding a chapter to an existing story with 2+ chapters still correctly triggers the subscription sheet for non-subscribers

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)