### PR TITLE
fix(reader): copy storyMode when reusing story details

### DIFF
--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
@@ -269,6 +269,7 @@ let readerReducer: Reducer<ReaderState, ReaderAction> = { state, action in
         newState.mainCharacter = story.mainCharacter
         newState.setting = story.setting
         newState.settingsState.perspective = story.perspective
+        newState.settingsState.storyMode = story.mode
         newState.selectedStoryForDetails = nil
         newState.showStoryForm = true
 


### PR DESCRIPTION
## Summary

Fixes #11.

When tapping "Use these details" in the story info popup, the story mode (Normal/Interactive) was not being copied to the new story form — only the main character, setting, and perspective were transferred.

- Added `newState.settingsState.storyMode = story.mode` in the `.reuseStoryDetails` case of `ReaderReducer.swift`, immediately after the perspective line.

## Test plan

- [ ] Open an existing story's info popup and tap "Use these details"
- [ ] Verify that the story mode (Normal/Interactive) in the new story form matches the source story's mode
- [ ] Confirm main character, setting, and perspective are still copied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)