### PR TITLE
fix(reader): persist story mode selection to settings on toggle

### DIFF
--- a/papyrus/papyrus/Packages/PapyrusStyleKit/Sources/PapyrusStyleKit/View/MenuButtonType.swift
+++ b/papyrus/papyrus/Packages/PapyrusStyleKit/Sources/PapyrusStyleKit/View/MenuButtonType.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-public enum MenuButtonType {
+public enum MenuButtonType: Sendable {
     case menu
     case settings
     case previous

--- a/papyrus/papyrus/Packages/Reader/Mocks/MockReaderEnvironment.swift
+++ b/papyrus/papyrus/Packages/Reader/Mocks/MockReaderEnvironment.swift
@@ -190,7 +190,7 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
         return createChapterReturnValue ?? story
     }
 
-    public func generateParagraph(story: Story) async throws -> Story {
+    public func generateParagraph(story: Story, sentenceCount _: Int) async throws -> Story {
         generateParagraphCalled = true
         generateParagraphCalledWith = story
 

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
@@ -242,6 +242,12 @@ let readerMiddleware: Middleware<ReaderState, ReaderAction, ReaderEnvironmentPro
         updatedStory.title = title
         return .saveStory(updatedStory)
 
+    case let .setInteractiveMode(mode):
+        var updatedSettings = state.settingsState
+        updatedSettings.storyMode = mode
+        try? await environment.settingsEnvironment.saveSettings(updatedSettings)
+        return nil
+
     case .failedToCreateChapter(_),
          .dismissGenerationError,
          .failedToLoadStories,
@@ -262,7 +268,6 @@ let readerMiddleware: Middleware<ReaderState, ReaderAction, ReaderEnvironmentPro
          .setCurrentScrollOffset,
          .reuseStoryDetails,
          .setScrollViewHeight,
-         .setInteractiveMode,
          .setInteractiveInputText,
          .undoInteractiveChapter,
          .redoInteractiveChapter:

--- a/papyrus/papyrus/Packages/Reader/Tests/ReaderTests/Redux/ReaderMiddlewareTests.swift
+++ b/papyrus/papyrus/Packages/Reader/Tests/ReaderTests/Redux/ReaderMiddlewareTests.swift
@@ -664,6 +664,36 @@ class ReaderMiddlewareTests {
         #expect(result == nil)
     }
 
+    // MARK: - Interactive Mode Tests
+
+    @Test
+    func setInteractiveMode_savesStoryModeToSettings() async {
+        let mockSettingsEnvironment = MockSettingsEnvironment()
+        let environment = MockReaderEnvironment(settingsEnvironment: mockSettingsEnvironment)
+        let state = ReaderState(settingsState: SettingsState(storyMode: .story))
+
+        let result = await readerMiddleware(state, .setInteractiveMode(.interactive), environment)
+
+        #expect(mockSettingsEnvironment.saveSettingsCalled)
+        #expect(mockSettingsEnvironment.saveSettingsCalledWith?.storyMode == .interactive)
+        #expect(result == nil)
+    }
+
+    @Test
+    func setInteractiveMode_preservesOtherSettingsFields() async {
+        let mockSettingsEnvironment = MockSettingsEnvironment()
+        let environment = MockReaderEnvironment(settingsEnvironment: mockSettingsEnvironment)
+        let initialSettings = SettingsState(storyMode: .interactive, sentenceCount: 5)
+        let state = ReaderState(settingsState: initialSettings)
+
+        let result = await readerMiddleware(state, .setInteractiveMode(.story), environment)
+
+        #expect(mockSettingsEnvironment.saveSettingsCalled)
+        #expect(mockSettingsEnvironment.saveSettingsCalledWith?.storyMode == .story)
+        #expect(mockSettingsEnvironment.saveSettingsCalledWith?.sentenceCount == 5)
+        #expect(result == nil)
+    }
+
     // MARK: - No-op Actions Test
 
     @Test

--- a/papyrus/papyrus/Packages/Settings/Mocks/SettingsState+Arrange.swift
+++ b/papyrus/papyrus/Packages/Settings/Mocks/SettingsState+Arrange.swift
@@ -5,6 +5,7 @@
 //  Created by Isaac Akalanne on 04/10/2025.
 //
 
+import Foundation
 import PapyrusStyleKit
 import Settings
 
@@ -16,8 +17,10 @@ public extension SettingsState {
     static func arrange(
         selectedTextSize: TextSize = .medium,
         isSubscribed: Bool = false,
+        perspective: StoryPerspective = .thirdPerson,
         selectedFontName: String = "Georgia",
         selectedColorSchemeName: PapyrusColorSchemeName = .parchment,
+        storyMode: StoryMode = .story,
         backgroundImages: [BackgroundImageEntry] = [],
         selectedBackgroundImageId: UUID? = nil,
         backgroundImageUsage: Set<BackgroundImageContext> = [],
@@ -26,8 +29,10 @@ public extension SettingsState {
         .init(
             selectedTextSize: selectedTextSize,
             isSubscribed: isSubscribed,
+            perspective: perspective,
             selectedFontName: selectedFontName,
             selectedColorSchemeName: selectedColorSchemeName,
+            storyMode: storyMode,
             backgroundImages: backgroundImages,
             selectedBackgroundImageId: selectedBackgroundImageId,
             backgroundImageUsage: backgroundImageUsage,

--- a/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsMiddlewareTests.swift
+++ b/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsMiddlewareTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PapyrusStyleKit
 @testable import Settings
 import SettingsMocks
 import Testing

--- a/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsReducerTests.swift
+++ b/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsReducerTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PapyrusStyleKit
 @testable import Settings
 import Testing
 

--- a/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationEnvironment.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationEnvironment.swift
@@ -159,7 +159,7 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
         return createChapterReturnValue ?? story
     }
 
-    public func generateParagraph(story: Story) async throws -> Story {
+    public func generateParagraph(story: Story, sentenceCount _: Int) async throws -> Story {
         generateParagraphCalled = true
         generateParagraphCalledWith = story
         generateParagraphCallCount += 1


### PR DESCRIPTION
## Summary
- Fixes #14: `.setInteractiveMode` was falling into the no-op return block in `ReaderMiddleware`, preventing story mode changes from persisting across sessions
- Adds a dedicated `case let .setInteractiveMode(mode):` handler that saves `storyMode` to `SettingsState` via `settingsEnvironment.saveSettings`, exactly mirroring how `updatePerspective` and `setSentenceCount` work
- Adds two unit tests covering the new middleware case: one verifying `saveSettings` is called with the correct mode, one verifying other settings fields are not mutated

## Pre-existing build fixes included
The test suite had accumulated several build-blocking issues unrelated to this fix; they are resolved here so CI can run:
- `SettingsState+Arrange`: missing `Foundation` import (`UUID`), missing `perspective`/`storyMode` parameters
- `SettingsReducerTests` / `SettingsMiddlewareTests`: missing `PapyrusStyleKit` import (`BackgroundImageContext`)
- `MockReaderEnvironment` / `MockTextGenerationEnvironment`: `generateParagraph` signature missing `sentenceCount` parameter
- `MenuButtonType`: missing `Sendable` conformance (required by `@Test(arguments:)`)

## Test plan
- [x] `setInteractiveMode_savesStoryModeToSettings` — verifies `saveSettings` is called with the toggled mode
- [x] `setInteractiveMode_preservesOtherSettingsFields` — verifies other settings fields (e.g. `sentenceCount`) are untouched
- [x] All existing `ReaderMiddlewareTests` that were passing before continue to pass
- [x] `swiftformat .` run — 0 files reformatted
- [x] Build succeeds (`xcodebuild build-for-testing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)