### PR TITLE
feat(text-generation): add ParseChapterSummariesEndpoint and ChapterSummary model

### DIFF
--- a/papyrus/papyrus/Packages/PapyrusStyleKit/Sources/PapyrusStyleKit/View/MenuButtonType.swift
+++ b/papyrus/papyrus/Packages/PapyrusStyleKit/Sources/PapyrusStyleKit/View/MenuButtonType.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-public enum MenuButtonType {
+public enum MenuButtonType: Sendable {
     case menu
     case settings
     case previous

--- a/papyrus/papyrus/Packages/Reader/Mocks/MockReaderEnvironment.swift
+++ b/papyrus/papyrus/Packages/Reader/Mocks/MockReaderEnvironment.swift
@@ -28,6 +28,9 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
     var createChapterBreakdownCalled = false
     var createChapterBreakdownCalledWith: Story?
 
+    var parseChapterSummariesCalled = false
+    var parseChapterSummariesCalledWith: Story?
+
     var getStoryDetailsCalled = false
     var getStoryDetailsCalledWith: Story?
 
@@ -70,6 +73,9 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
 
     var createChapterBreakdownReturnValue: Story?
     var createChapterBreakdownError: Error?
+
+    var parseChapterSummariesReturnValue: Story?
+    var parseChapterSummariesError: Error?
 
     var getStoryDetailsReturnValue: Story?
     var getStoryDetailsError: Error?
@@ -157,6 +163,17 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
         return createChapterBreakdownReturnValue ?? story
     }
 
+    public func parseChapterSummaries(story: Story) async throws -> Story {
+        parseChapterSummariesCalled = true
+        parseChapterSummariesCalledWith = story
+
+        if let error = parseChapterSummariesError {
+            throw error
+        }
+
+        return parseChapterSummariesReturnValue ?? story
+    }
+
     public func getStoryDetails(story: Story) async throws -> Story {
         getStoryDetailsCalled = true
         getStoryDetailsCalledWith = story
@@ -190,7 +207,7 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
         return createChapterReturnValue ?? story
     }
 
-    public func generateParagraph(story: Story) async throws -> Story {
+    public func generateParagraph(story: Story, sentenceCount _: Int) async throws -> Story {
         generateParagraphCalled = true
         generateParagraphCalledWith = story
 

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderAction.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderAction.swift
@@ -38,6 +38,8 @@ public indirect enum ReaderAction: Equatable, Sendable {
     case onCreatedPlotOutline(Story)
     case createChapterBreakdown(Story)
     case onCreatedChapterBreakdown(Story)
+    case parseChapterSummaries(Story)
+    case onParsedChapterSummaries(Story)
     case getStoryDetails(Story)
     case onGetStoryDetails(Story)
     case getChapterTitle(Story)

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
@@ -120,6 +120,17 @@ let readerMiddleware: Middleware<ReaderState, ReaderAction, ReaderEnvironmentPro
         }
 
     case let .onCreatedChapterBreakdown(story):
+        return .parseChapterSummaries(story)
+
+    case let .parseChapterSummaries(story):
+        do {
+            let storyWithSummaries = try await environment.parseChapterSummaries(story: story)
+            return .onParsedChapterSummaries(storyWithSummaries)
+        } catch {
+            return .failedToCreateChapter(.parseChapterSummaries(story))
+        }
+
+    case let .onParsedChapterSummaries(story):
         if story.maxNumberOfChapters > 0 {
             return .beginCreateChapter(story)
         } else {
@@ -265,7 +276,8 @@ let readerMiddleware: Middleware<ReaderState, ReaderAction, ReaderEnvironmentPro
          .setInteractiveMode,
          .setInteractiveInputText,
          .undoInteractiveChapter,
-         .redoInteractiveChapter:
+         .redoInteractiveChapter,
+         .onParsedChapterSummaries:
         return nil
     }
 }

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
@@ -133,6 +133,14 @@ let readerReducer: Reducer<ReaderState, ReaderAction> = { state, action in
         newState.isLoading = true
         newState = updateStoryInState(newState, story: story)
 
+    case let .parseChapterSummaries(story):
+        newState.isLoading = true
+        newState = updateStoryInState(newState, story: story)
+
+    case let .onParsedChapterSummaries(story):
+        newState.isLoading = true
+        newState = updateStoryInState(newState, story: story)
+
     case let .getStoryDetails(story):
         newState.isLoading = true
         newState.loadingStep = .analyzingStructure

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Services/ReaderEnvironment.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Services/ReaderEnvironment.swift
@@ -15,6 +15,7 @@ public protocol ReaderEnvironmentProtocol {
     func createPlotOutline(story: Story) async throws -> Story
     func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story
     func createChapterBreakdown(story: Story) async throws -> Story
+    func parseChapterSummaries(story: Story) async throws -> Story
     func getStoryDetails(story: Story) async throws -> Story
     func getChapterTitle(story: Story) async throws -> Story
     func createChapter(story: Story) async throws -> Story
@@ -62,6 +63,10 @@ public struct ReaderEnvironment: ReaderEnvironmentProtocol {
 
     public func createChapterBreakdown(story: Story) async throws -> Story {
         try await textGenerationEnvironment.createChapterBreakdown(story: story)
+    }
+
+    public func parseChapterSummaries(story: Story) async throws -> Story {
+        try await textGenerationEnvironment.parseChapterSummaries(story: story)
     }
 
     public func getStoryDetails(story: Story) async throws -> Story {

--- a/papyrus/papyrus/Packages/Reader/Tests/ReaderTests/Redux/ReaderMiddlewareTests.swift
+++ b/papyrus/papyrus/Packages/Reader/Tests/ReaderTests/Redux/ReaderMiddlewareTests.swift
@@ -147,23 +147,34 @@ class ReaderMiddlewareTests {
     }
 
     @Test
-    func onCreatedChapterBreakdown_withChapters_returnsBeginCreateChapter() async {
+    func onCreatedChapterBreakdown_returnsParseChapterSummaries() async {
         let state = ReaderState()
         let environment = MockReaderEnvironment()
         let story = Story(maxNumberOfChapters: 5, title: "Test Story")
 
         let result = await readerMiddleware(state, .onCreatedChapterBreakdown(story), environment)
 
+        #expect(result == .parseChapterSummaries(story))
+    }
+
+    @Test
+    func onParsedChapterSummaries_withChapters_returnsBeginCreateChapter() async {
+        let state = ReaderState()
+        let environment = MockReaderEnvironment()
+        let story = Story(maxNumberOfChapters: 5, title: "Test Story")
+
+        let result = await readerMiddleware(state, .onParsedChapterSummaries(story), environment)
+
         #expect(result == .beginCreateChapter(story))
     }
 
     @Test
-    func onCreatedChapterBreakdown_noChapters_returnsGetStoryDetails() async {
+    func onParsedChapterSummaries_noChapters_returnsGetStoryDetails() async {
         let state = ReaderState()
         let environment = MockReaderEnvironment()
         let story = Story(maxNumberOfChapters: 0, title: "Test Story")
 
-        let result = await readerMiddleware(state, .onCreatedChapterBreakdown(story), environment)
+        let result = await readerMiddleware(state, .onParsedChapterSummaries(story), environment)
 
         #expect(result == .getStoryDetails(story))
     }

--- a/papyrus/papyrus/Packages/Settings/Mocks/SettingsState+Arrange.swift
+++ b/papyrus/papyrus/Packages/Settings/Mocks/SettingsState+Arrange.swift
@@ -5,12 +5,13 @@
 //  Created by Isaac Akalanne on 04/10/2025.
 //
 
+import Foundation
 import PapyrusStyleKit
 import Settings
 
 public extension SettingsState {
     static var arrange: SettingsState {
-        arrange()
+        SettingsState.arrange()
     }
 
     static func arrange(

--- a/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsMiddlewareTests.swift
+++ b/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsMiddlewareTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PapyrusStyleKit
 @testable import Settings
 import SettingsMocks
 import Testing

--- a/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsReducerTests.swift
+++ b/papyrus/papyrus/Packages/Settings/Tests/SettingsTests/Redux/SettingsReducerTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PapyrusStyleKit
 @testable import Settings
 import Testing
 

--- a/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationEnvironment.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationEnvironment.swift
@@ -27,6 +27,10 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
     public var createChapterBreakdownCalledWith: Story?
     public var createChapterBreakdownCallCount = 0
 
+    public var parseChapterSummariesCalled = false
+    public var parseChapterSummariesCalledWith: Story?
+    public var parseChapterSummariesCallCount = 0
+
     public var getStoryDetailsCalled = false
     public var getStoryDetailsCalledWith: Story?
     public var getStoryDetailsCallCount = 0
@@ -56,6 +60,9 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
 
     public var createChapterBreakdownReturnValue: Story?
     public var createChapterBreakdownError: Error?
+
+    public var parseChapterSummariesReturnValue: Story?
+    public var parseChapterSummariesError: Error?
 
     public var getStoryDetailsReturnValue: Story?
     public var getStoryDetailsError: Error?
@@ -123,6 +130,18 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
         return createChapterBreakdownReturnValue ?? story
     }
 
+    public func parseChapterSummaries(story: Story) async throws -> Story {
+        parseChapterSummariesCalled = true
+        parseChapterSummariesCalledWith = story
+        parseChapterSummariesCallCount += 1
+
+        if let error = parseChapterSummariesError {
+            throw error
+        }
+
+        return parseChapterSummariesReturnValue ?? story
+    }
+
     public func getStoryDetails(story: Story) async throws -> Story {
         getStoryDetailsCalled = true
         getStoryDetailsCalledWith = story
@@ -159,7 +178,7 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
         return createChapterReturnValue ?? story
     }
 
-    public func generateParagraph(story: Story) async throws -> Story {
+    public func generateParagraph(story: Story, sentenceCount _: Int) async throws -> Story {
         generateParagraphCalled = true
         generateParagraphCalledWith = story
         generateParagraphCallCount += 1
@@ -190,6 +209,10 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
         createChapterBreakdownCalledWith = nil
         createChapterBreakdownCallCount = 0
 
+        parseChapterSummariesCalled = false
+        parseChapterSummariesCalledWith = nil
+        parseChapterSummariesCallCount = 0
+
         getStoryDetailsCalled = false
         getStoryDetailsCalledWith = nil
         getStoryDetailsCallCount = 0
@@ -213,6 +236,9 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
 
         createChapterBreakdownReturnValue = nil
         createChapterBreakdownError = nil
+
+        parseChapterSummariesReturnValue = nil
+        parseChapterSummariesError = nil
 
         getStoryDetailsReturnValue = nil
         getStoryDetailsError = nil

--- a/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationRepository.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationRepository.swift
@@ -27,6 +27,10 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
     public var createChapterBreakdownCalledWith: Story?
     public var createChapterBreakdownCallCount = 0
 
+    public var parseChapterSummariesCalled = false
+    public var parseChapterSummariesCalledWith: Story?
+    public var parseChapterSummariesCallCount = 0
+
     public var getStoryDetailsCalled = false
     public var getStoryDetailsCalledWith: Story?
     public var getStoryDetailsCallCount = 0
@@ -56,6 +60,9 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
 
     public var createChapterBreakdownReturnValue: Story?
     public var createChapterBreakdownError: Error?
+
+    public var parseChapterSummariesReturnValue: Story?
+    public var parseChapterSummariesError: Error?
 
     public var getStoryDetailsReturnValue: Story?
     public var getStoryDetailsError: Error?
@@ -121,6 +128,18 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
         }
 
         return createChapterBreakdownReturnValue ?? originalStory
+    }
+
+    public func parseChapterSummaries(story originalStory: Story) async throws -> Story {
+        parseChapterSummariesCalled = true
+        parseChapterSummariesCalledWith = originalStory
+        parseChapterSummariesCallCount += 1
+
+        if let error = parseChapterSummariesError {
+            throw error
+        }
+
+        return parseChapterSummariesReturnValue ?? originalStory
     }
 
     public func getStoryDetails(story originalStory: Story) async throws -> Story {
@@ -213,6 +232,12 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
 
         createChapterBreakdownReturnValue = nil
         createChapterBreakdownError = nil
+
+        parseChapterSummariesCalled = false
+        parseChapterSummariesCalledWith = nil
+        parseChapterSummariesCallCount = 0
+        parseChapterSummariesReturnValue = nil
+        parseChapterSummariesError = nil
 
         getStoryDetailsReturnValue = nil
         getStoryDetailsError = nil

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/ParseChapterSummariesEndpoint.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/ParseChapterSummariesEndpoint.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SDNetworkCore
+
+struct ParseChapterSummariesEndpoint: Endpoint {
+    typealias Response = OpenRouterResponse
+
+    let story: Story
+
+    var path: String {
+        "/api/v1/chat/completions"
+    }
+
+    var body: Data? {
+        let messages = [
+            OpenRouterMessage(
+                role: "system",
+                content: "You are a precise data extraction assistant. Output only valid JSON with no markdown formatting, code blocks, or additional text."
+            ),
+            OpenRouterMessage(
+                role: "user",
+                content: """
+                Parse the following chapter breakdown into a JSON array. Each element must have exactly two fields:
+                - "chapterNumber": an integer representing the chapter number
+                - "summary": a string containing a concise summary of that chapter
+
+                Output only valid JSON — no markdown, no code fences, no explanation. The output must start with [ and end with ].
+
+                Chapter breakdown:
+                \(story.chaptersBreakdown)
+                """
+            ),
+        ]
+
+        let request = OpenRouterRequest(
+            messages: messages,
+            reasoning: OpenRouterReasoning()
+        )
+
+        return request.toData()
+    }
+}

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Model/ChapterSummary.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Model/ChapterSummary.swift
@@ -1,0 +1,19 @@
+//
+//  ChapterSummary.swift
+//  TextGeneration
+//
+
+import Foundation
+
+public struct ChapterSummary: Codable, Equatable, Sendable {
+    public var chapterNumber: Int
+    public var summary: String
+
+    public init(
+        chapterNumber: Int,
+        summary: String
+    ) {
+        self.chapterNumber = chapterNumber
+        self.summary = summary
+    }
+}

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Model/Story.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Model/Story.swift
@@ -15,6 +15,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
     var themeDescription: String
     var plotOutline: String
     var chaptersBreakdown: String
+    public var chapterSummaries: [ChapterSummary]
     public var chapterIndex: Int
     public var maxNumberOfChapters: Int
     public var scrollOffset: CGFloat
@@ -33,6 +34,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
         themeDescription: String = "",
         plotOutline: String = "",
         chaptersBreakdown: String = "",
+        chapterSummaries: [ChapterSummary] = [],
         chapterIndex: Int = 0,
         maxNumberOfChapters: Int = 0,
         scrollOffset: CGFloat = 0,
@@ -49,6 +51,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
         self.themeDescription = themeDescription
         self.plotOutline = plotOutline
         self.chaptersBreakdown = chaptersBreakdown
+        self.chapterSummaries = chapterSummaries
         self.chapterIndex = chapterIndex
         self.maxNumberOfChapters = maxNumberOfChapters
         self.scrollOffset = scrollOffset
@@ -70,6 +73,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
         themeDescription = try container.decodeIfPresent(String.self, forKey: .themeDescription) ?? ""
         plotOutline = try container.decode(String.self, forKey: .plotOutline)
         chaptersBreakdown = try container.decode(String.self, forKey: .chaptersBreakdown)
+        chapterSummaries = try container.decodeIfPresent([ChapterSummary].self, forKey: .chapterSummaries) ?? []
         chapterIndex = try container.decode(Int.self, forKey: .chapterIndex)
         maxNumberOfChapters = try container.decodeIfPresent(Int.self, forKey: .maxNumberOfChapters) ?? 0
         scrollOffset = try container.decodeIfPresent(CGFloat.self, forKey: .scrollOffset) ?? 0

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationEnvironment.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationEnvironment.swift
@@ -12,6 +12,7 @@ public protocol TextGenerationEnvironmentProtocol {
     func createPlotOutline(story: Story) async throws -> Story
     func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story
     func createChapterBreakdown(story: Story) async throws -> Story
+    func parseChapterSummaries(story: Story) async throws -> Story
     func getStoryDetails(story: Story) async throws -> Story
     func getChapterTitle(story: Story) async throws -> Story
     func createChapter(story: Story) async throws -> Story
@@ -41,6 +42,10 @@ public struct TextGenerationEnvironment: TextGenerationEnvironmentProtocol {
 
     public func createChapterBreakdown(story: Story) async throws -> Story {
         try await repository.createChapterBreakdown(story: story)
+    }
+
+    public func parseChapterSummaries(story: Story) async throws -> Story {
+        try await repository.parseChapterSummaries(story: story)
     }
 
     public func getStoryDetails(story: Story) async throws -> Story {

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationRepository.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationRepository.swift
@@ -9,6 +9,7 @@ public protocol TextGenerationRepositoryProtocol {
     func getStoryDetails(story originalStory: Story) async throws -> Story
     func getChapterTitle(story originalStory: Story) async throws -> Story
     func createChapter(story originalStory: Story) async throws -> Story
+    func parseChapterSummaries(story originalStory: Story) async throws -> Story
     func generateParagraph(story originalStory: Story, sentenceCount: Int) async throws -> Story
 }
 
@@ -90,6 +91,16 @@ public class TextGenerationRepository: TextGenerationRepositoryProtocol {
         let content = try await networkCore.requestContent(endpoint)
 
         story.chapters.append(.init(content: content))
+        return story
+    }
+
+    public func parseChapterSummaries(story originalStory: Story) async throws -> Story {
+        var story = originalStory
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+        let content = try await networkCore.requestContent(endpoint)
+
+        let jsonData = Data(content.utf8)
+        story.chapterSummaries = try JSONDecoder().decode([ChapterSummary].self, from: jsonData)
         return story
     }
 

--- a/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/ParseChapterSummariesEndpointTests.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/ParseChapterSummariesEndpointTests.swift
@@ -1,0 +1,215 @@
+//
+//  ParseChapterSummariesEndpointTests.swift
+//  TextGeneration
+//
+
+import Foundation
+import SDNetworkCore
+import Testing
+@testable import TextGeneration
+
+class ParseChapterSummariesEndpointTests {
+    // MARK: - Initialization Tests
+
+    @Test
+    func initialization() {
+        let chaptersBreakdown = "Chapter 1: The hero departs. Chapter 2: The first trial."
+        let story = Story(chaptersBreakdown: chaptersBreakdown)
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        #expect(endpoint.story.chaptersBreakdown == chaptersBreakdown)
+    }
+
+    // MARK: - Path Tests
+
+    @Test
+    func path() {
+        let story = Story()
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        #expect(endpoint.path == "/api/v1/chat/completions")
+    }
+
+    // MARK: - Body Tests
+
+    @Test
+    func body_createsValidData() {
+        let story = Story(chaptersBreakdown: "Chapter 1: Introduction to the world.")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+
+        #expect(bodyData != nil)
+        #expect(bodyData!.count > 0)
+    }
+
+    @Test
+    func body_containsCorrectJSON() throws {
+        let chaptersBreakdown = "Chapter 1: The protagonist discovers a secret map."
+        let story = Story(chaptersBreakdown: chaptersBreakdown)
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        #expect(json != nil)
+
+        #expect(json?["model"] as? String == "x-ai/grok-4-fast")
+
+        let messages = json?["messages"] as? [[String: Any]]
+        #expect(messages?.count == 2)
+
+        let systemMessage = messages?[0]
+        #expect(systemMessage?["role"] as? String == "system")
+
+        let userMessage = messages?[1]
+        #expect(userMessage?["role"] as? String == "user")
+    }
+
+    @Test
+    func body_systemMessage_instructsJSONOnlyOutput() throws {
+        let story = Story(chaptersBreakdown: "Chapter 1: Adventure begins.")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let systemMessage = messages?[0]
+        let systemContent = systemMessage?["content"] as? String
+
+        #expect(systemContent?.contains("valid JSON") == true)
+        #expect(systemContent?.contains("no markdown") == true)
+    }
+
+    @Test
+    func body_userMessage_includesChaptersBreakdown() throws {
+        let chaptersBreakdown = "Chapter 1: A mysterious letter arrives.\nChapter 2: The journey to the north."
+        let story = Story(chaptersBreakdown: chaptersBreakdown)
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains(chaptersBreakdown) == true)
+    }
+
+    @Test
+    func body_userMessage_specifiesJSONSchema() throws {
+        let story = Story(chaptersBreakdown: "Chapter 1: The beginning.")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("chapterNumber") == true)
+        #expect(userContent?.contains("summary") == true)
+    }
+
+    @Test
+    func body_userMessage_instructsJSONArrayOutput() throws {
+        let story = Story(chaptersBreakdown: "Chapter 1: Setting the scene.")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("[") == true)
+        #expect(userContent?.contains("]") == true)
+    }
+
+    @Test
+    func body_userMessage_forbidsMarkdownWrapper() throws {
+        let story = Story(chaptersBreakdown: "Chapter 1: The call to adventure.")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("no markdown") == true || userContent?.contains("code fences") == true)
+    }
+
+    @Test
+    func body_handlesEmptyChaptersBreakdown() throws {
+        let story = Story(chaptersBreakdown: "")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+
+        #expect(messages?.count == 2)
+    }
+
+    @Test
+    func body_includesReasoning() throws {
+        let story = Story(chaptersBreakdown: "Chapter 1: Test.")
+        let endpoint = ParseChapterSummariesEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+
+        let reasoning = json?["reasoning"] as? [String: Any]
+        #expect(reasoning != nil)
+        #expect(reasoning?["max_tokens"] as? Int == 5000)
+    }
+
+    // MARK: - Response Type Tests
+
+    @Test
+    func responseType() {
+        let story = Story()
+        _ = ParseChapterSummariesEndpoint(story: story)
+
+        let _: OpenRouterResponse.Type = ParseChapterSummariesEndpoint.Response.self
+
+        #expect(true)
+    }
+
+    // MARK: - Response Decoding Tests
+
+    @Test
+    func responseContent_decodesIntoChapterSummaries() throws {
+        let jsonContent = """
+        [
+          {"chapterNumber": 1, "summary": "The hero departs on a quest."},
+          {"chapterNumber": 2, "summary": "The first obstacle is overcome."},
+          {"chapterNumber": 3, "summary": "An unexpected ally joins."}
+        ]
+        """
+        let data = Data(jsonContent.utf8)
+        let summaries = try JSONDecoder().decode([ChapterSummary].self, from: data)
+
+        #expect(summaries.count == 3)
+        #expect(summaries[0].chapterNumber == 1)
+        #expect(summaries[0].summary == "The hero departs on a quest.")
+        #expect(summaries[1].chapterNumber == 2)
+        #expect(summaries[2].chapterNumber == 3)
+    }
+}

--- a/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Model/ChapterSummaryTests.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Model/ChapterSummaryTests.swift
@@ -1,0 +1,101 @@
+//
+//  ChapterSummaryTests.swift
+//  TextGeneration
+//
+
+import Foundation
+import Testing
+@testable import TextGeneration
+
+class ChapterSummaryTests {
+    // MARK: - Initialization Tests
+
+    @Test
+    func initialization_storesProperties() {
+        let summary = ChapterSummary(chapterNumber: 3, summary: "The hero faces the dragon.")
+
+        #expect(summary.chapterNumber == 3)
+        #expect(summary.summary == "The hero faces the dragon.")
+    }
+
+    // MARK: - Equatable Tests
+
+    @Test
+    func equatable_equalValues_areEqual() {
+        let lhs = ChapterSummary(chapterNumber: 1, summary: "Opening chapter")
+        let rhs = ChapterSummary(chapterNumber: 1, summary: "Opening chapter")
+
+        #expect(lhs == rhs)
+    }
+
+    @Test
+    func equatable_differentChapterNumber_areNotEqual() {
+        let lhs = ChapterSummary(chapterNumber: 1, summary: "Opening chapter")
+        let rhs = ChapterSummary(chapterNumber: 2, summary: "Opening chapter")
+
+        #expect(lhs != rhs)
+    }
+
+    @Test
+    func equatable_differentSummary_areNotEqual() {
+        let lhs = ChapterSummary(chapterNumber: 1, summary: "Opening chapter")
+        let rhs = ChapterSummary(chapterNumber: 1, summary: "Closing chapter")
+
+        #expect(lhs != rhs)
+    }
+
+    // MARK: - Codable Tests
+
+    @Test
+    func encode_producesExpectedJSON() throws {
+        let summary = ChapterSummary(chapterNumber: 5, summary: "A twist is revealed.")
+
+        let data = try JSONEncoder().encode(summary)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(json?["chapterNumber"] as? Int == 5)
+        #expect(json?["summary"] as? String == "A twist is revealed.")
+    }
+
+    @Test
+    func decode_fromValidJSON_producesCorrectModel() throws {
+        let json = """
+        {"chapterNumber": 7, "summary": "The climax arrives."}
+        """
+        let data = Data(json.utf8)
+
+        let summary = try JSONDecoder().decode(ChapterSummary.self, from: data)
+
+        #expect(summary.chapterNumber == 7)
+        #expect(summary.summary == "The climax arrives.")
+    }
+
+    @Test
+    func decode_array_fromValidJSON_producesCorrectModels() throws {
+        let json = """
+        [
+          {"chapterNumber": 1, "summary": "The journey begins."},
+          {"chapterNumber": 2, "summary": "The first obstacle."}
+        ]
+        """
+        let data = Data(json.utf8)
+
+        let summaries = try JSONDecoder().decode([ChapterSummary].self, from: data)
+
+        #expect(summaries.count == 2)
+        #expect(summaries[0].chapterNumber == 1)
+        #expect(summaries[0].summary == "The journey begins.")
+        #expect(summaries[1].chapterNumber == 2)
+        #expect(summaries[1].summary == "The first obstacle.")
+    }
+
+    @Test
+    func roundTrip_encodeAndDecode_preservesValues() throws {
+        let original = ChapterSummary(chapterNumber: 42, summary: "An unexpected ally appears.")
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChapterSummary.self, from: encoded)
+
+        #expect(decoded == original)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #21

- Adds `ChapterSummary` model (`chapterNumber: Int`, `summary: String`) with full `Codable/Equatable/Sendable` conformance
- Adds `ParseChapterSummariesEndpoint` that sends `chaptersBreakdown` to the AI and expects a JSON array response; JSON decoding happens in `TextGenerationRepository`
- Updates `Story` with `chapterSummaries: [ChapterSummary]` defaulting to `[]`, decoded with `decodeIfPresent`
- Inserts `parseChapterSummaries` as a pipeline step between `onCreatedChapterBreakdown` and the existing `getStoryDetails`/`beginCreateChapter` branch in `ReaderMiddleware`
- Updates `TextGenerationEnvironmentProtocol`, `TextGenerationRepositoryProtocol`, `ReaderEnvironmentProtocol`, and all mocks to include the new method
- Adds unit tests: `ChapterSummaryTests` (init, Equatable, Codable round-trip) and `ParseChapterSummariesEndpointTests` (prompt construction, JSON schema instructions, response decoding)
- Fixes pre-existing compile errors in Settings and PapyrusStyleKit test targets that were blocking the test run

## Test plan

- [x] `ChapterSummaryTests` — all pass
- [x] `ParseChapterSummariesEndpointTests` — all pass
- [x] Full `TextGenerationTests` suite passes (130 tests; 1 pre-existing unrelated failure in `GetChapterTitleEndpointTests`)
- [x] Project builds successfully (`** BUILD SUCCEEDED **`)
- [x] `swiftformat .` run with no files reformatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)