### PR TITLE
feat(story): add CondensePlotOutlineEndpoint and plotSummary (#22)

### DIFF
--- a/papyrus/papyrus/Packages/Reader/Mocks/MockReaderEnvironment.swift
+++ b/papyrus/papyrus/Packages/Reader/Mocks/MockReaderEnvironment.swift
@@ -22,6 +22,9 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
     var createPlotOutlineCalled = false
     var createPlotOutlineCalledWith: Story?
 
+    var condensePlotOutlineCalled = false
+    var condensePlotOutlineCalledWith: Story?
+
     var createSequelPlotOutlineCalled = false
     var createSequelPlotOutlineCalledWith: (story: Story, previousStory: Story)?
 
@@ -67,6 +70,9 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
 
     var createPlotOutlineReturnValue: Story?
     var createPlotOutlineError: Error?
+
+    var condensePlotOutlineReturnValue: Story?
+    var condensePlotOutlineError: Error?
 
     var createSequelPlotOutlineReturnValue: Story?
     var createSequelPlotOutlineError: Error?
@@ -139,6 +145,17 @@ public class MockReaderEnvironment: ReaderEnvironmentProtocol {
         }
 
         return createPlotOutlineReturnValue ?? story
+    }
+
+    public func condensePlotOutline(story: Story) async throws -> Story {
+        condensePlotOutlineCalled = true
+        condensePlotOutlineCalledWith = story
+
+        if let error = condensePlotOutlineError {
+            throw error
+        }
+
+        return condensePlotOutlineReturnValue ?? story
     }
 
     public func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story {

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderAction.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderAction.swift
@@ -36,6 +36,8 @@ public indirect enum ReaderAction: Equatable, Sendable {
     case onCreatedThemeDescription(Story)
     case createPlotOutline(Story)
     case onCreatedPlotOutline(Story)
+    case condensePlotOutline(Story)
+    case onCondensedPlotOutline(Story)
     case createChapterBreakdown(Story)
     case onCreatedChapterBreakdown(Story)
     case parseChapterSummaries(Story)

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderMiddleware.swift
@@ -109,6 +109,17 @@ let readerMiddleware: Middleware<ReaderState, ReaderAction, ReaderEnvironmentPro
         }
 
     case let .onCreatedPlotOutline(story):
+        return .condensePlotOutline(story)
+
+    case let .condensePlotOutline(story):
+        do {
+            let storyWithSummary = try await environment.condensePlotOutline(story: story)
+            return .onCondensedPlotOutline(storyWithSummary)
+        } catch {
+            return .failedToCreateChapter(.condensePlotOutline(story))
+        }
+
+    case let .onCondensedPlotOutline(story):
         return .createChapterBreakdown(story)
 
     case let .createChapterBreakdown(story):

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
@@ -124,11 +124,8 @@ let readerReducer: Reducer<ReaderState, ReaderAction> = { state, action in
         newState.isLoading = true
         newState = updateStoryInState(newState, story: story)
 
-    case let .condensePlotOutline(story):
-        newState.isLoading = true
-        newState = updateStoryInState(newState, story: story)
-
-    case let .onCondensedPlotOutline(story):
+    case let .condensePlotOutline(story),
+         let .onCondensedPlotOutline(story):
         newState.isLoading = true
         newState = updateStoryInState(newState, story: story)
 

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Redux/ReaderReducer.swift
@@ -124,6 +124,14 @@ let readerReducer: Reducer<ReaderState, ReaderAction> = { state, action in
         newState.isLoading = true
         newState = updateStoryInState(newState, story: story)
 
+    case let .condensePlotOutline(story):
+        newState.isLoading = true
+        newState = updateStoryInState(newState, story: story)
+
+    case let .onCondensedPlotOutline(story):
+        newState.isLoading = true
+        newState = updateStoryInState(newState, story: story)
+
     case let .createChapterBreakdown(story):
         newState.isLoading = true
         newState.loadingStep = .creatingChapterBreakdown

--- a/papyrus/papyrus/Packages/Reader/Sources/Reader/Services/ReaderEnvironment.swift
+++ b/papyrus/papyrus/Packages/Reader/Sources/Reader/Services/ReaderEnvironment.swift
@@ -13,6 +13,7 @@ import TextGeneration
 public protocol ReaderEnvironmentProtocol {
     func createStoryTheme(story: Story) async throws -> Story
     func createPlotOutline(story: Story) async throws -> Story
+    func condensePlotOutline(story: Story) async throws -> Story
     func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story
     func createChapterBreakdown(story: Story) async throws -> Story
     func parseChapterSummaries(story: Story) async throws -> Story
@@ -55,6 +56,10 @@ public struct ReaderEnvironment: ReaderEnvironmentProtocol {
 
     public func createPlotOutline(story: Story) async throws -> Story {
         try await textGenerationEnvironment.createPlotOutline(story: story)
+    }
+
+    public func condensePlotOutline(story: Story) async throws -> Story {
+        try await textGenerationEnvironment.condensePlotOutline(story: story)
     }
 
     public func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story {

--- a/papyrus/papyrus/Packages/Reader/Tests/ReaderTests/Redux/ReaderMiddlewareTests.swift
+++ b/papyrus/papyrus/Packages/Reader/Tests/ReaderTests/Redux/ReaderMiddlewareTests.swift
@@ -106,12 +106,53 @@ class ReaderMiddlewareTests {
     }
 
     @Test
-    func onCreatedPlotOutline_returnsCreateChapterBreakdown() async {
+    func onCreatedPlotOutline_returnsCondensePlotOutline() async {
         let state = ReaderState()
         let environment = MockReaderEnvironment()
         let story = Story(title: "Test Story")
 
         let result = await readerMiddleware(state, .onCreatedPlotOutline(story), environment)
+
+        #expect(result == .condensePlotOutline(story))
+    }
+
+    // MARK: - Condense Plot Outline Tests
+
+    @Test
+    func condensePlotOutline_success_returnsOnCondensedPlotOutline() async {
+        let state = ReaderState()
+        let environment = MockReaderEnvironment()
+        let inputStory = Story(title: "Input Story")
+        let outputStory = Story(plotOutline: "Full outline", title: "Output Story")
+        environment.condensePlotOutlineReturnValue = outputStory
+
+        let result = await readerMiddleware(state, .condensePlotOutline(inputStory), environment)
+
+        #expect(environment.condensePlotOutlineCalled)
+        #expect(environment.condensePlotOutlineCalledWith?.id == inputStory.id)
+        #expect(result == .onCondensedPlotOutline(outputStory))
+    }
+
+    @Test
+    func condensePlotOutline_failure_returnsFailedToCreateChapter() async {
+        let state = ReaderState()
+        let environment = MockReaderEnvironment()
+        let inputStory = Story(title: "Input Story")
+        environment.condensePlotOutlineError = ReaderTestError("Condense failed")
+
+        let result = await readerMiddleware(state, .condensePlotOutline(inputStory), environment)
+
+        #expect(environment.condensePlotOutlineCalled)
+        #expect(result == .failedToCreateChapter(.condensePlotOutline(inputStory)))
+    }
+
+    @Test
+    func onCondensedPlotOutline_returnsCreateChapterBreakdown() async {
+        let state = ReaderState()
+        let environment = MockReaderEnvironment()
+        let story = Story(title: "Test Story")
+
+        let result = await readerMiddleware(state, .onCondensedPlotOutline(story), environment)
 
         #expect(result == .createChapterBreakdown(story))
     }

--- a/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationEnvironment.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationEnvironment.swift
@@ -19,6 +19,10 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
     public var createPlotOutlineCalledWith: Story?
     public var createPlotOutlineCallCount = 0
 
+    public var condensePlotOutlineCalled = false
+    public var condensePlotOutlineCalledWith: Story?
+    public var condensePlotOutlineCallCount = 0
+
     public var createSequelPlotOutlineCalled = false
     public var createSequelPlotOutlineCalledWith: (story: Story, previousStory: Story)?
     public var createSequelPlotOutlineCallCount = 0
@@ -54,6 +58,9 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
 
     public var createPlotOutlineReturnValue: Story?
     public var createPlotOutlineError: Error?
+
+    public var condensePlotOutlineReturnValue: Story?
+    public var condensePlotOutlineError: Error?
 
     public var createSequelPlotOutlineReturnValue: Story?
     public var createSequelPlotOutlineError: Error?
@@ -104,6 +111,18 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
         }
 
         return createPlotOutlineReturnValue ?? story
+    }
+
+    public func condensePlotOutline(story: Story) async throws -> Story {
+        condensePlotOutlineCalled = true
+        condensePlotOutlineCalledWith = story
+        condensePlotOutlineCallCount += 1
+
+        if let error = condensePlotOutlineError {
+            throw error
+        }
+
+        return condensePlotOutlineReturnValue ?? story
     }
 
     public func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story {
@@ -201,6 +220,10 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
         createPlotOutlineCalledWith = nil
         createPlotOutlineCallCount = 0
 
+        condensePlotOutlineCalled = false
+        condensePlotOutlineCalledWith = nil
+        condensePlotOutlineCallCount = 0
+
         createSequelPlotOutlineCalled = false
         createSequelPlotOutlineCalledWith = nil
         createSequelPlotOutlineCallCount = 0
@@ -230,6 +253,9 @@ public class MockTextGenerationEnvironment: TextGenerationEnvironmentProtocol {
 
         createPlotOutlineReturnValue = nil
         createPlotOutlineError = nil
+
+        condensePlotOutlineReturnValue = nil
+        condensePlotOutlineError = nil
 
         createSequelPlotOutlineReturnValue = nil
         createSequelPlotOutlineError = nil

--- a/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationRepository.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Mocks/MockTextGenerationRepository.swift
@@ -19,6 +19,10 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
     public var createPlotOutlineCalledWith: Story?
     public var createPlotOutlineCallCount = 0
 
+    public var condensePlotOutlineCalled = false
+    public var condensePlotOutlineCalledWith: Story?
+    public var condensePlotOutlineCallCount = 0
+
     public var createSequelPlotOutlineCalled = false
     public var createSequelPlotOutlineCalledWith: (story: Story, previousStory: Story)?
     public var createSequelPlotOutlineCallCount = 0
@@ -54,6 +58,9 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
 
     public var createPlotOutlineReturnValue: Story?
     public var createPlotOutlineError: Error?
+
+    public var condensePlotOutlineReturnValue: Story?
+    public var condensePlotOutlineError: Error?
 
     public var createSequelPlotOutlineReturnValue: Story?
     public var createSequelPlotOutlineError: Error?
@@ -104,6 +111,18 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
         }
 
         return createPlotOutlineReturnValue ?? originalStory
+    }
+
+    public func condensePlotOutline(story originalStory: Story) async throws -> Story {
+        condensePlotOutlineCalled = true
+        condensePlotOutlineCalledWith = originalStory
+        condensePlotOutlineCallCount += 1
+
+        if let error = condensePlotOutlineError {
+            throw error
+        }
+
+        return condensePlotOutlineReturnValue ?? originalStory
     }
 
     public func createSequelPlotOutline(story originalStory: Story, previousStory: Story) async throws -> Story {
@@ -201,6 +220,10 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
         createPlotOutlineCalledWith = nil
         createPlotOutlineCallCount = 0
 
+        condensePlotOutlineCalled = false
+        condensePlotOutlineCalledWith = nil
+        condensePlotOutlineCallCount = 0
+
         createSequelPlotOutlineCalled = false
         createSequelPlotOutlineCalledWith = nil
         createSequelPlotOutlineCallCount = 0
@@ -226,6 +249,9 @@ public class MockTextGenerationRepository: TextGenerationRepositoryProtocol {
 
         createPlotOutlineReturnValue = nil
         createPlotOutlineError = nil
+
+        condensePlotOutlineReturnValue = nil
+        condensePlotOutlineError = nil
 
         createSequelPlotOutlineReturnValue = nil
         createSequelPlotOutlineError = nil

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/CondensePlotOutlineEndpoint.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/CondensePlotOutlineEndpoint.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SDNetworkCore
+
+struct CondensePlotOutlineEndpoint: Endpoint {
+    typealias Response = OpenRouterResponse
+
+    let story: Story
+
+    var path: String {
+        "/api/v1/chat/completions"
+    }
+
+    var body: Data? {
+        let messages = [
+            OpenRouterMessage(
+                role: "system",
+                content: "You are a master story analyst. Distill story outlines into precise, compelling loglines. Output only the requested sentences with no preamble, labels, or markdown."
+            ),
+            OpenRouterMessage(
+                role: "user",
+                content: """
+                Distill the following plot outline into exactly 3–5 sentences that capture: the genre, the protagonist and their core motivation, the central conflict, the stakes, and the thematic resolution.
+
+                Output only the sentences — no preamble, no labels, no markdown.
+
+                Plot outline:
+                \(story.plotOutline)
+                """
+            ),
+        ]
+
+        let request = OpenRouterRequest(
+            messages: messages,
+            reasoning: OpenRouterReasoning()
+        )
+
+        return request.toData()
+    }
+}

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Model/Story.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Model/Story.swift
@@ -14,6 +14,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
     public var setting: String
     var themeDescription: String
     var plotOutline: String
+    var plotSummary: String
     var chaptersBreakdown: String
     public var chapterSummaries: [ChapterSummary]
     public var chapterIndex: Int
@@ -33,6 +34,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
         setting: String = "",
         themeDescription: String = "",
         plotOutline: String = "",
+        plotSummary: String = "",
         chaptersBreakdown: String = "",
         chapterSummaries: [ChapterSummary] = [],
         chapterIndex: Int = 0,
@@ -50,6 +52,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
         self.setting = setting
         self.themeDescription = themeDescription
         self.plotOutline = plotOutline
+        self.plotSummary = plotSummary
         self.chaptersBreakdown = chaptersBreakdown
         self.chapterSummaries = chapterSummaries
         self.chapterIndex = chapterIndex
@@ -72,6 +75,7 @@ public struct Story: Codable, Equatable, Sendable, Identifiable {
         setting = try container.decode(String.self, forKey: .setting)
         themeDescription = try container.decodeIfPresent(String.self, forKey: .themeDescription) ?? ""
         plotOutline = try container.decode(String.self, forKey: .plotOutline)
+        plotSummary = try container.decodeIfPresent(String.self, forKey: .plotSummary) ?? ""
         chaptersBreakdown = try container.decode(String.self, forKey: .chaptersBreakdown)
         chapterSummaries = try container.decodeIfPresent([ChapterSummary].self, forKey: .chapterSummaries) ?? []
         chapterIndex = try container.decode(Int.self, forKey: .chapterIndex)

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationEnvironment.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationEnvironment.swift
@@ -10,6 +10,7 @@ import Foundation
 public protocol TextGenerationEnvironmentProtocol {
     func createStoryTheme(story: Story) async throws -> Story
     func createPlotOutline(story: Story) async throws -> Story
+    func condensePlotOutline(story: Story) async throws -> Story
     func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story
     func createChapterBreakdown(story: Story) async throws -> Story
     func parseChapterSummaries(story: Story) async throws -> Story
@@ -34,6 +35,10 @@ public struct TextGenerationEnvironment: TextGenerationEnvironmentProtocol {
 
     public func createPlotOutline(story: Story) async throws -> Story {
         try await repository.createPlotOutline(story: story)
+    }
+
+    public func condensePlotOutline(story: Story) async throws -> Story {
+        try await repository.condensePlotOutline(story: story)
     }
 
     public func createSequelPlotOutline(story: Story, previousStory: Story) async throws -> Story {

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationRepository.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Service/TextGenerationRepository.swift
@@ -4,6 +4,7 @@ import SDNetworkCore
 public protocol TextGenerationRepositoryProtocol {
     func createStoryTheme(story originalStory: Story) async throws -> Story
     func createPlotOutline(story originalStory: Story) async throws -> Story
+    func condensePlotOutline(story originalStory: Story) async throws -> Story
     func createSequelPlotOutline(story originalStory: Story, previousStory: Story) async throws -> Story
     func createChapterBreakdown(story originalStory: Story) async throws -> Story
     func getStoryDetails(story originalStory: Story) async throws -> Story
@@ -37,6 +38,15 @@ public class TextGenerationRepository: TextGenerationRepositoryProtocol {
         let content = try await networkCore.requestContent(endpoint)
 
         story.plotOutline = content
+        return story
+    }
+
+    public func condensePlotOutline(story originalStory: Story) async throws -> Story {
+        var story = originalStory
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+        let content = try await networkCore.requestContent(endpoint)
+
+        story.plotSummary = content.trimmingCharacters(in: .whitespacesAndNewlines)
         return story
     }
 

--- a/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/CondensePlotOutlineEndpointTests.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/CondensePlotOutlineEndpointTests.swift
@@ -1,0 +1,196 @@
+//
+//  CondensePlotOutlineEndpointTests.swift
+//  TextGeneration
+//
+
+import Foundation
+import SDNetworkCore
+import Testing
+@testable import TextGeneration
+
+class CondensePlotOutlineEndpointTests {
+    // MARK: - Initialization Tests
+
+    @Test
+    func initialization() {
+        let plotOutline = "A hero journeys into the unknown to save the world."
+        let story = Story(plotOutline: plotOutline)
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        #expect(endpoint.story.plotOutline == plotOutline)
+    }
+
+    // MARK: - Path Tests
+
+    @Test
+    func path() {
+        let story = Story()
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        #expect(endpoint.path == "/api/v1/chat/completions")
+    }
+
+    // MARK: - Body Tests
+
+    @Test
+    func body_createsValidData() {
+        let story = Story(plotOutline: "A sweeping epic about loss and redemption.")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+
+        #expect(bodyData != nil)
+        #expect(bodyData!.count > 0)
+    }
+
+    @Test
+    func body_containsCorrectJSON() throws {
+        let plotOutline = "A warrior rises to defend a fallen kingdom."
+        let story = Story(plotOutline: plotOutline)
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        #expect(json != nil)
+
+        #expect(json?["model"] as? String == "x-ai/grok-4-fast")
+
+        let messages = json?["messages"] as? [[String: Any]]
+        #expect(messages?.count == 2)
+
+        let systemMessage = messages?[0]
+        #expect(systemMessage?["role"] as? String == "system")
+
+        let userMessage = messages?[1]
+        #expect(userMessage?["role"] as? String == "user")
+    }
+
+    @Test
+    func body_systemMessage_instructsNoPreamble() throws {
+        let story = Story(plotOutline: "An orphan discovers her magical heritage.")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let systemMessage = messages?[0]
+        let systemContent = systemMessage?["content"] as? String
+
+        #expect(systemContent?.contains("no preamble") == true)
+        #expect(systemContent?.contains("markdown") == true)
+    }
+
+    @Test
+    func body_userMessage_includesPlotOutline() throws {
+        let plotOutline = "A detective uncovers a conspiracy that reaches the highest offices of power."
+        let story = Story(plotOutline: plotOutline)
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains(plotOutline) == true)
+    }
+
+    @Test
+    func body_userMessage_requestsThreeToFiveSentences() throws {
+        let story = Story(plotOutline: "A quiet village is threatened by ancient evil.")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("3") == true)
+        #expect(userContent?.contains("5") == true)
+    }
+
+    @Test
+    func body_userMessage_specifiesRequiredElements() throws {
+        let story = Story(plotOutline: "An astronaut is stranded on Mars.")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("genre") == true)
+        #expect(userContent?.contains("protagonist") == true)
+        #expect(userContent?.contains("conflict") == true)
+        #expect(userContent?.contains("stakes") == true)
+    }
+
+    @Test
+    func body_userMessage_instructsNoPreamble() throws {
+        let story = Story(plotOutline: "A time traveller tries to fix a mistake.")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("no preamble") == true)
+    }
+
+    @Test
+    func body_handlesEmptyPlotOutline() throws {
+        let story = Story(plotOutline: "")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+
+        #expect(messages?.count == 2)
+    }
+
+    @Test
+    func body_includesReasoning() throws {
+        let story = Story(plotOutline: "A rebellion against a tyrannical empire.")
+        let endpoint = CondensePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+
+        let reasoning = json?["reasoning"] as? [String: Any]
+        #expect(reasoning != nil)
+        #expect(reasoning?["max_tokens"] as? Int == 5000)
+    }
+
+    // MARK: - Response Type Tests
+
+    @Test
+    func responseType() {
+        let story = Story()
+        _ = CondensePlotOutlineEndpoint(story: story)
+
+        let _: OpenRouterResponse.Type = CondensePlotOutlineEndpoint.Response.self
+
+        #expect(true)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `CondensePlotOutlineEndpoint` that takes `story.plotOutline` and calls the model to distil it into a 3–5 sentence logline (genre, protagonist & motivation, central conflict, stakes, thematic resolution)
- Adds `plotSummary: String` to `Story` (defaults to `""`, decoded with `decodeIfPresent` for backwards compatibility)
- Inserts a `condensePlotOutline` / `onCondensedPlotOutline` step into the generation pipeline between `onCreatedPlotOutline` and `createChapterBreakdown`
- Wires `condensePlotOutline` through all layers: repository protocol + implementation, environment protocol + implementation + mock, reader environment protocol + implementation + mock, Redux actions, middleware, and reducer

## Test plan

- [ ] `CondensePlotOutlineEndpointTests` — covers path, body structure, system/user message content, reasoning, and empty input
- [ ] `ReaderMiddlewareTests` — updated `onCreatedPlotOutline_returnsCondensePlotOutline`, and new tests for `condensePlotOutline` (success + failure) and `onCondensedPlotOutline`
- [ ] All new tests pass; no new failures introduced (pre-existing `GetChapterTitleEndpointTests` and `ReaderReducerTests` failures are unrelated to this change)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)