### PR TITLE
feat(prompts): add no-quoted-dialogue instruction to plot outline and chapter breakdown endpoints

### DIFF
--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/CreateChapterBreakdownEndpoint.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/CreateChapterBreakdownEndpoint.swift
@@ -28,6 +28,8 @@ struct CreateChapterBreakdownEndpoint: Endpoint {
                 Expand the plot outline into a chapter-by-chapter breakdown for a complete story. Aim for 40-55 chapters to fit a novel-length narrative (200,000-250,000 words), distributing chapters logically across the three acts (e.g., 10-15 in Act 1, 23-25 in Act 2, 7-10 in Act 3). Each chapter must stand alone in the breakdown with its own dedicated outline—no grouping chapters into ranges (e.g., avoid "Chapters 5-7"; treat each as "Chapter 5," "Chapter 6," etc.). Ensure the breakdown faithfully adapts the plot outline while adding granular details like key scenes, character arcs, dialogue hooks, and sensory elements to make it vivid and actionable.
 
                 Generate the chapter breakdown now, ensuring it's polished, immersive, and optimized for writing a gripping story.
+
+                Do not include quoted character dialogue unless quoted speech is present in the provided setting. Describe characters' actions, intentions, and emotional beats in narrative summary form.
                 """
             ),
         ]

--- a/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/CreatePlotOutlineEndpoint.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Sources/TextGeneration/Endpoints/CreatePlotOutlineEndpoint.swift
@@ -31,6 +31,8 @@ struct CreatePlotOutlineEndpoint: Endpoint {
                 Develop a high-quality plot outline that integrates the setting and main character seamlessly. The outline should be original, engaging, and emotionally resonant, with clear stakes, escalating conflict, and satisfying resolution. Aim for a story length equivalent to a novel (around 200,000-250,000 words if written out).
 
                 Generate the plot outline now, ensuring it's polished, professional, and ready to inspire a full story.
+
+                Do not include quoted character dialogue unless quoted speech is present in the provided setting. Describe characters' actions, intentions, and emotional beats in narrative summary form.
                 """
             ),
         ]

--- a/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/CreateChapterBreakdownEndpointTests.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/CreateChapterBreakdownEndpointTests.swift
@@ -232,6 +232,23 @@ class CreateChapterBreakdownEndpointTests {
         #expect(reasoning?["max_tokens"] as? Int == 5000)
     }
 
+    @Test
+    func body_includesNoDialogueInstruction() throws {
+        let story = Story(plotOutline: "A heist in a futuristic megacity")
+        let endpoint = CreateChapterBreakdownEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("Do not include quoted character dialogue") == true)
+        #expect(userContent?.contains("Describe characters' actions, intentions, and emotional beats in narrative summary form") == true)
+    }
+
     // MARK: - Response Type Tests
 
     @Test

--- a/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/CreatePlotOutlineEndpointTests.swift
+++ b/papyrus/papyrus/Packages/TextGeneration/Tests/TextGenerationTests/Endpoints/CreatePlotOutlineEndpointTests.swift
@@ -172,6 +172,23 @@ class CreatePlotOutlineEndpointTests {
         #expect(reasoning?["max_tokens"] as? Int == 5000)
     }
 
+    @Test
+    func body_includesNoDialogueInstruction() throws {
+        let story = Story(mainCharacter: "Wanderer Jin", setting: "Ancient forest")
+        let endpoint = CreatePlotOutlineEndpoint(story: story)
+
+        let bodyData = endpoint.body
+        #expect(bodyData != nil)
+
+        let json = try JSONSerialization.jsonObject(with: bodyData!) as? [String: Any]
+        let messages = json?["messages"] as? [[String: Any]]
+        let userMessage = messages?[1]
+        let userContent = userMessage?["content"] as? String
+
+        #expect(userContent?.contains("Do not include quoted character dialogue") == true)
+        #expect(userContent?.contains("Describe characters' actions, intentions, and emotional beats in narrative summary form") == true)
+    }
+
     // MARK: - Response Type Tests
 
     @Test


### PR DESCRIPTION
## Summary
- Appends the no-quoted-dialogue instruction to the user prompt in `CreatePlotOutlineEndpoint`
- Appends the same instruction to the user prompt in `CreateChapterBreakdownEndpoint`
- Adds `body_includesNoDialogueInstruction()` unit tests to both endpoint test files

## Test plan
- [ ] `body_includesNoDialogueInstruction()` passes in `CreatePlotOutlineEndpointTests`
- [ ] `body_includesNoDialogueInstruction()` passes in `CreateChapterBreakdownEndpointTests`
- [ ] All other existing TextGeneration tests continue to pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)